### PR TITLE
user Router component directly as main function

### DIFF
--- a/js/components/Router/index.js
+++ b/js/components/Router/index.js
@@ -40,7 +40,7 @@ export default function Router(sources) {
   const vdom$ = xs.combine(nav$, view$)
     .map(([navDom, viewDom]) => div([navDom, viewDom]));
 
-  const sinks = merge(sources, {DOM: vdom$});
-
-  return sinks;
+  return {
+    DOM: vdom$
+  }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -2,11 +2,11 @@ import {run} from '@cycle/xstream-run';
 import {makeDOMDriver} from '@cycle/dom';
 import {createHistory} from 'history';
 import {makeRouterDriver} from 'cyclic-router';
-import Main from './root';
+import Router from './components/Router/index';
 
 const drivers = {
   DOM: makeDOMDriver('#root'),
   router: makeRouterDriver(createHistory(), {capture: true})
 };
 
-run(Main, drivers);
+run(Router, drivers);

--- a/js/root/index.js
+++ b/js/root/index.js
@@ -1,8 +1,0 @@
-import Router from '../components/Router';
-
-export default function Main(sources) {
-  const router = Router({...sources});
-  return {
-    DOM: router.DOM
-  };
-};


### PR DESCRIPTION
In *js/components/Router/index.js* `sources` is added to sinks. However, `sources` is never used (see *js/root/index.js*). If you do not add `sources` to sinks, you can use `Router` directly as main function and delete *js/root/index.js*. This reduces complexity.