### PR TITLE
Support components with HTTP sink

### DIFF
--- a/js/components/Router/index.js
+++ b/js/components/Router/index.js
@@ -41,6 +41,7 @@ export default function Router(sources) {
     .map(([navDom, viewDom]) => div([navDom, viewDom]));
 
   return {
-    DOM: vdom$
+    DOM: vdom$,
+    HTTP: page$.map(prop('HTTP')).filter(Boolean).flatten()
   }
 }

--- a/js/components/Router/index.js
+++ b/js/components/Router/index.js
@@ -3,6 +3,7 @@ import {div, nav, a, h3, p} from '@cycle/dom';
 import {merge, prop} from 'ramda';
 import BMI from '../../examples/bmi';
 import Hello from '../../examples/hello-world';
+import {HttpRequest} from "../../examples/http-request";
 
 function NotFound(sources) {
   const vdom$ = xs.of(div([
@@ -21,6 +22,7 @@ export default function Router(sources) {
   const match$ = router.define({
     '/bmi': BMI,
     '/hello': Hello,
+    '/http': HttpRequest,
     '*': NotFound
   });
 
@@ -32,7 +34,8 @@ export default function Router(sources) {
 
   const nav$ = xs.of(nav({style: {marginBottom: '1em'}}, [
     makeLink('/bmi', 'BMI'),
-    makeLink('/hello', 'Hello')
+    makeLink('/hello', 'Hello'),
+    makeLink('/http', 'Http'),
   ]));
 
   const view$ = page$.map(prop('DOM')).flatten();

--- a/js/components/Router/index.js
+++ b/js/components/Router/index.js
@@ -40,7 +40,7 @@ export default function Router(sources) {
   const vdom$ = xs.combine(nav$, view$)
     .map(([navDom, viewDom]) => div([navDom, viewDom]));
 
-  const sinks = merge(sources, {DOM: vdom$});
-
-  return sinks;
+  return {
+    DOM: vdom$
+  }
 }

--- a/js/examples/http-request.js
+++ b/js/examples/http-request.js
@@ -1,0 +1,22 @@
+import Stream from 'xstream';
+import {div, h1} from '@cycle/dom';
+
+export function HttpRequest(sources) {
+    const request$ = Stream.of({
+        category: 'ip-request',
+        url: 'https://httpbin.org/ip'
+    });
+    const response$ = sources.HTTP.select('ip-request').flatten();
+    const vdom$ = response$
+        .map(res => `IP address: ${res.body.origin}`)
+        .startWith('Requesting IP address...')
+        .map(text =>
+            div('.container', [
+                h1(text),
+            ])
+        );
+    return {
+        DOM: vdom$,
+        HTTP: request$
+    };
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,13 @@
 import {run} from '@cycle/xstream-run';
 import {makeDOMDriver} from '@cycle/dom';
+import {makeHTTPDriver} from '@cycle/http';
 import {createHistory} from 'history';
 import {makeRouterDriver} from 'cyclic-router';
 import Router from './components/Router/index';
 
 const drivers = {
   DOM: makeDOMDriver('#root'),
+  HTTP: makeHTTPDriver(),
   router: makeRouterDriver(createHistory(), {capture: true})
 };
 

--- a/js/main.js
+++ b/js/main.js
@@ -2,11 +2,11 @@ import {run} from '@cycle/xstream-run';
 import {makeDOMDriver} from '@cycle/dom';
 import {createHistory} from 'history';
 import {makeRouterDriver} from 'cyclic-router';
-import Main from './root';
+import Router from './components/Router/index';
 
 const drivers = {
   DOM: makeDOMDriver('#root'),
   router: makeRouterDriver(createHistory(), {capture: true})
 };
 
-run(Main, drivers);
+run(Router, drivers);

--- a/js/root/index.js
+++ b/js/root/index.js
@@ -1,8 +1,0 @@
-import Router from '../components/Router';
-
-export default function Main(sources) {
-  const router = Router({...sources});
-  return {
-    DOM: router.DOM
-  };
-};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@cycle/dom": "^10.0.2",
+    "@cycle/http": "^11.2.0",
     "@cycle/isolate": "^1.4.0",
     "@cycle/xstream-run": "^3.0.3",
     "cyclic-router": "^2.1.2",


### PR DESCRIPTION
`@cycle/http` is a common sink of components. I added an example component that does a HTTP request to [httpbin.org/ip](https://httpbin.org/ip) and forwarded the `HTTP` sink of the `Router` child components.

**Note:** This pull request is based on the changes of pull request #9 (not merged yet).